### PR TITLE
LIBCIR-21. Google Analytics key property.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1948,7 +1948,7 @@ webui.suggest.enable = false
 # inside that snipet is your Google Analytics key usually found in this line:
 # _uacct = "UA-XXXXXXX-X"
 # Take this key (just the UA-XXXXXX-X part) and place it here in this parameter.
-# jspui.google.analytics.key=UA-XXXXXX-X
+# jspui.google.analytics.key=${google.analytics.key}
 
 #---------------------------------------------------------------#
 #--------------XMLUI SPECIFIC CONFIGURATIONS--------------------#
@@ -2056,8 +2056,7 @@ mirage2.item-view.bitstream.href.label.2 = title
 # inside that snipet is your Google Analytics key usually found in this line:
 # _uacct = "UA-XXXXXXX-X"
 # Take this key (just the UA-XXXXXX-X part) and place it here in this parameter.
-#xmlui.google.analytics.key=UA-XXXXXX-X
-
+xmlui.google.analytics.key=${google.analytics.key}
 # Assign how many page views will be recorded and displayed in the control panel's
 # activity viewer. The activity tab allows an administrator to debug problems in a
 # running DSpace by understanding who and how their dspace is currently being used.


### PR DESCRIPTION
The dspace.cfg reads the google.analytics.key property (to be set in the {dev,stage,prod}.properties file) for setting the {jspui,xmlui}.google.analytics.key properties. Enabled the xmlui.google.analytics.key property.

https://issues.umd.edu/browse/LIBCIR-21