### PR TITLE
LIBCIR-48. Investigate Mirage2 Prerequisite Installation procedure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The original DSpace documentation:
 * [README](README)
 * [DSpace Manual](dspace/docs/pdf/DSpace-Manual.pdf)
 * [Theme Customization](dspace/docs/ThemeCustomization.md)
+* [Mirage2 Prerequisites on Server](dspace/docs/Mirage2PrerequisitesOnServer.md)
 
 ### Installation
 Instructions for installing in UMD Libraries development environments (Mac OS-X):

--- a/dspace/docs/LocalBuildInstructions.md
+++ b/dspace/docs/LocalBuildInstructions.md
@@ -73,3 +73,15 @@ Follow the documentation on the [mdsoar-vagrant](https://github.com/umd-lib/mdso
 
 ### Ant local build option
 Use the `ant update_local` option to do updates without creating backups of the previous deployment files. This would cut down on the time taken create the backups.
+
+## Mirage2 Prerequisites
+Follow the [instructions](../../dspace-xmlui-mirage2/readme.md#prerequisites-for-osx--linux) from the main dspace-xmlui-mirage2 project to install the prerequisites on your workstation. 
+
+Until the prerequisites are installed you need to add `-Dmirage2.deps.included=true` maven build parameter to include the prerequisites using maven:
+
+```
+mvn package -Denv=local -Dmirage2.deps.included=true
+```
+
+See [Mirage2PrerequisitesOnServer.md](./Mirage2PrerequisitesOnServer.md) for installing the prequisites on servers.
+

--- a/dspace/docs/Mirage2PrerequisitesOnServer.md
+++ b/dspace/docs/Mirage2PrerequisitesOnServer.md
@@ -1,0 +1,27 @@
+# Mirage2 Prerequisites on Server
+Follow the [instructions](../../dspace-xmlui-mirage2/readme.md#prerequisites-for-osx--linux) from the main dspace-xmlui-mirage2 project to install the prerequisites. The installation might not be starightforward on a redhat server.
+
+###Possible issues and workarounds:
+* All the installation commands from the above insturctions has to be run the service account user.
+* The service account user needs to have sudo privilege to successfully install ruby.
+* Ruby installtion guidelines:
+  * Start the installation  
+  `\curl -sSL https://get.rvm.io | bash -s stable --ruby`
+  * If you get a prompt to import signature, import the signature and start the installation again.
+  
+    ```
+    $ gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3`
+    $ \curl -sSL https://get.rvm.io | bash -s stable --ruby
+    ```
+  * Enter the (sudo-enabled) service account password when prompted with the following message:
+  `<USER> password required for 'rhn-channel -l'`
+  * Press `ctrl+c` when the following prompt appears: 
+  
+    ```
+    Enabling optional repository
+    Password: Username:
+    ```
+  * Intallation would proceed and complete.
+* Continue to install the gems as per the instructions.
+
+**Note:** If you get `command not found` messages after successfull installation, restart your shell session.

--- a/dspace/modules/xmlui-mirage2-communities/pom.xml
+++ b/dspace/modules/xmlui-mirage2-communities/pom.xml
@@ -21,7 +21,7 @@
         <root.basedir>${basedir}/../../..</root.basedir>
         <grunt.environment>prod</grunt.environment>
         <grunt.color.scheme>classic_mirage_color_scheme</grunt.color.scheme>
-        <mirage2.deps.included>true</mirage2.deps.included>
+        <mirage2.deps.included>false</mirage2.deps.included>
         <!-- Versions of build dependencies to be auto-installed when "mirage2.deps.included=true" -->
         <sass.version>3.3.14</sass.version>
         <compass.version>1.0.1</compass.version>
@@ -213,6 +213,7 @@
         <profile>
             <id>mirage2-deps-preinstalled-fast</id>
             <activation>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>mirage2.deps.included</name>
                     <value>false</value>
@@ -337,7 +338,6 @@
         <profile>
             <id>mirage2-deps-included-slow</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>mirage2.deps.included</name>
                     <value>true</value>

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -21,7 +21,7 @@
         <root.basedir>${basedir}/../../..</root.basedir>
         <grunt.environment>prod</grunt.environment>
         <grunt.color.scheme>classic_mirage_color_scheme</grunt.color.scheme>
-        <mirage2.deps.included>true</mirage2.deps.included>
+        <mirage2.deps.included>false</mirage2.deps.included>
         <!-- Versions of build dependencies to be auto-installed when "mirage2.deps.included=true" -->
         <sass.version>3.3.14</sass.version>
         <compass.version>1.0.1</compass.version>
@@ -197,6 +197,7 @@
         <profile>
             <id>mirage2-deps-preinstalled-fast</id>
             <activation>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>mirage2.deps.included</name>
                     <value>false</value>
@@ -321,7 +322,6 @@
         <profile>
             <id>mirage2-deps-included-slow</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>mirage2.deps.included</name>
                     <value>true</value>


### PR DESCRIPTION
Made Dmirage2.deps.included=false by default.
Updated documentation.

https://issues.umd.edu/browse/LIBCIR-48