### PR TITLE
LIBCIR-55. Disable solr webapp module.

### DIFF
--- a/dspace/modules/pom.xml
+++ b/dspace/modules/pom.xml
@@ -85,6 +85,9 @@
             </modules>
         </profile>
         <profile>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
             <id>dspace-solr</id>
             <modules>
                 <module>solr</module>
@@ -120,7 +123,6 @@
                 <module>xmlui</module>
                 <module>rdf</module>
                 <module>rest</module>
-                <module>solr</module>
                 <module>oai</module>
                 <module>xmlui-mirage2</module>
                 <module>xmlui-mirage2-communities</module>
@@ -142,7 +144,6 @@
                 <module>rest</module>
                 <module>sword</module>
                 <module>swordv2</module>
-                <module>solr</module>
                 <module>oai</module>
                 <module>xmlui-mirage2</module>
                 <module>xmlui-mirage2-communities</module>

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -188,7 +188,7 @@ Common usage:
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
-    <target name="update" depends="update_configs,update_code,update_webapps,update_solr_indexes" description="Update installed code and web applications (without clobbering data/config)">
+    <target name="update" depends="update_configs,update_code,update_webapps" description="Update installed code and web applications (without clobbering data/config)">
     </target>
 
     <target name="update_local" description="Update installed code and web applications without backups (without clobbering data/config)">

--- a/pom.xml
+++ b/pom.xml
@@ -607,9 +607,7 @@
         <profile>
             <id>dspace-solr</id>
             <activation>
-                <file>
-                    <exists>dspace-solr/pom.xml</exists>
-                </file>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <modules>
                 <module>dspace-solr</module>


### PR DESCRIPTION
Maven will only build solr on all-modules profile.
Ant solr index upgrade will not happen on "ant update"

https://issues.umd.edu/browse/LIBCIR-55