### PR TITLE
LIBCIR-65. batch load succeeds, but items do not appear in collection.

### DIFF
--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -72,10 +72,10 @@
        The examples below can be used to load some solr-contribs along 
        with their external dependencies.
     -->
-  <!--
-  <lib dir="../../../contrib/extraction/lib" regex=".*\.jar" />
-  <lib dir="../../../dist/" regex="solr-cell-\d.*\.jar" />
+  <lib dir="../../contrib/extraction/lib" regex=".*\.jar" />
+  <lib dir="../../dist/" regex="solr-cell-\d.*\.jar" />
 
+  <!--
   <lib dir="../../../contrib/clustering/lib/" regex=".*\.jar" />
   <lib dir="../../../dist/" regex="solr-clustering-\d.*\.jar" />
 


### PR DESCRIPTION
Enabled extraction and solr-cell jars for the batch import indexing to work.

https://issues.umd.edu/browse/LIBCIR-65