### PR TITLE
LIBCIR-73. Sort metadata fields in full item view by element and qualifier.

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/aspect/artifactbrowser/item-view.xsl
@@ -451,7 +451,10 @@
         <xsl:call-template name="itemSummaryView-DIM-title"/>
         <div class="ds-table-responsive">
             <table class="ds-includeSet-table detailtable table table-striped table-hover">
-                <xsl:apply-templates mode="itemDetailView-DIM"/>
+                <xsl:apply-templates mode="itemDetailView-DIM">
+                    <xsl:sort select="@element"/>
+                    <xsl:sort select="@qualifier"/>
+                </xsl:apply-templates>
             </table>
         </div>
 


### PR DESCRIPTION
The sort ignores the mdschema for a field on the assumption that the user is going to be thinking in terms of the field name or qualifier.

https://issues.umd.edu/browse/LIBCIR-73