### PR TITLE
LIBCIR-71. Enable the ImageMagick thumbnailer.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -439,7 +439,8 @@ http.proxy.port = ${http.proxy.port}
 #Names of the enabled MediaFilter or FormatFilter plugins
 filter.plugins = PDF Text Extractor, HTML Text Extractor, \
                  PowerPoint Text Extractor, \
-                 Word Text Extractor, JPEG Thumbnail
+                 ImageMagick Image Thumbnail, ImageMagick PDF Thumbnail, \
+                 Word Text Extractor
 
 # [To enable Branded Preview]: uncomment and insert the following into the plugin list
 #                Branded Preview JPEG, \


### PR DESCRIPTION
The PDF thumbnailer requires that ghostscript be installed on the server.

https://issues.umd.edu/browse/LIBCIR-71