### PR TITLE
LIBCIR-263. Orcid implementation changes.

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
@@ -10,7 +10,7 @@
 
     Handlebars.registerHelper('set_selected', function(value, options) {
         var $el = $('<select />').html( options.fn(this) );
-        $el.find('[value=' + value + ']').attr({'selected':'selected'});
+        $el.find('[value="' + value + '"]').attr({'selected':'selected'});
         return $el.html();
     });
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1041,7 +1041,7 @@ webui.strengths.show = false
 webui.browse.index.1 = dateissued:item:dateissued
 #webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text
 webui.browse.index.2 = title:item:title
-webui.browse.index.3 = author:metadata:dc.contributor.author\,dc.creator\,dcterms.creator:text
+webui.browse.index.3 = author:metadata:dc.contributor.author\,dc.creator:text
 webui.browse.index.4 = subject:metadata:dc.coverage.spatial\,dc.coverage.temporal\,dc.coverage\,dc.subject.classification\,dc.subject.*\,dc.subject\,dcterms.temporal\,dcterms.subject\,dcterms.spatial\,dcterms.coverage:text
 webui.browse.index.5 = type:metadata:dc.format\,dc.genre\,dc.type:text
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -259,7 +259,7 @@
         <div class="simple-item-view-authors item-page-field-wrapper table">
           <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-author-orcid</i18n:text></h5>
           <xsl:for-each select="dim:field[@element='creator']">
-            <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
+            <xsl:call-template name="itemSummaryView-DIM-author-orcids-entry" />
           </xsl:for-each>
         </div>
       </xsl:if>
@@ -284,6 +284,25 @@
             <!--  End Customization LIBCIR-164 -->
         </div>
     </xsl:template>
+
+    <!--  Customization for LIBCIR-263 -->
+    <xsl:template name="itemSummaryView-DIM-author-orcids-entry">
+        <div>
+            <xsl:if test="@authority">
+                <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
+            </xsl:if>
+            
+            <a>
+	            <xsl:attribute name="href">
+			            <xsl:value-of select="$context-path"/>
+			            <xsl:text>/discover?filtertype_1=dcterms.creator&amp;filter_relational_operator_1=contains&amp;filter_1=</xsl:text>
+			            <xsl:copy-of select="node()"/>
+	            </xsl:attribute>
+	            <i18n:text><xsl:copy-of select="node()"/></i18n:text>
+            </a> 
+        </div>
+    </xsl:template>
+    <!--  End Customization LIBCIR-263 -->
 
     <xsl:template name="itemSummaryView-DIM-URI">
         <xsl:if test="dim:field[@element='identifier' and @qualifier='uri' and descendant::text()]">


### PR DESCRIPTION
- Remove dcterms.creator from the Author browse index
- Update item view page Orcid link to use search filter instead of browse index.
- Fix javascript to display filters with selected value containing dot.

https://issues.umd.edu/browse/LIBCIR-263