### PR TITLE
LIBCIR-288. Added "start-handle-server-fg" script

### DIFF
--- a/dspace/bin/start-handle-server-fg
+++ b/dspace/bin/start-handle-server-fg
@@ -1,0 +1,45 @@
+#!/bin/sh
+###########################################################################
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+###########################################################################
+# 'start-handle-server' script
+# Unix shell script for starting Handle server.  WARNING this assumes any
+# previously running Handle servers have been terminated.
+
+# Assume we're in the bin subdirectory of the DSpace installation directory
+BINDIR=`dirname $0`
+
+# Read parameters from DSpace config
+DSPACEDIR=`$BINDIR/dspace dsprop --property dspace.dir`
+HANDLEDIR=`$BINDIR/dspace dsprop --property handle.dir`
+
+# Assume log directory is a subdirectory of DSPACEDIR.
+# If you want your handle server logs stored elsewhere, change this value
+LOGDIR=$DSPACEDIR/log
+
+# Get the JARs in $DSPACEDIR/jsp/WEB-INF/lib, separated by ':'
+JARS=`echo $DSPACEDIR/lib/*.jar | sed 's/ /\:/g'`
+
+# Class path for DSpace will be:
+#   Any existing classpath
+#   The JARs (WEB-INF/lib/*.jar)
+#   The WEB-INF/classes directory
+FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
+
+#Allow user to specify java options through JAVA_OPTS variable
+if [ "$JAVA_OPTS" = "" ]; then
+    #Default Java to use 256MB of memory
+    JAVA_OPTS=-Xmx256m
+fi
+
+# Remove lock file, in case the old Handle server did not shut down properly
+rm -f $HANDLEDIR/txns/lock
+
+# Start the Handle server, with a special log4j properties file.
+# We cannot simply write to the same logs, since log4j
+# does not support more than one JVM writing to the same rolling log.
+java $JAVA_OPTS -classpath $FULLPATH -Ddspace.log.init.disable=true -Dlog4j.configuration=log4j-handle-plugin.properties net.handle.server.Main $HANDLEDIR </dev/null >> $LOGDIR/handle-server.log 2>&1


### PR DESCRIPTION
Added "dspace/bin/start-handle-server-fg" script, as it is needed by the "k8s-mdsoar" DSpace 7 configuration.

https://umd-dit.atlassian.net/browse/LIBCIR-288
