### PR TITLE
LIBCIR-291. Ignore failing SystemWideAlertRestRepositoryIT.java tests

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
@@ -30,6 +30,7 @@ import org.dspace.alerts.SystemWideAlert;
 import org.dspace.app.rest.model.SystemWideAlertRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.SystemWideAlertBuilder;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -37,6 +38,9 @@ import org.junit.Test;
  */
 public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrationTest {
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void findAllTest() throws Exception {
         // Create two alert entries in the db to fully test the findAll method
@@ -136,6 +140,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     }
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void findOneTest() throws Exception {
         // Create two alert entries in the db to fully test the findOne method
@@ -178,6 +185,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
     }
 
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void findOneUnauthorizedTest() throws Exception {
         // Create two alert entries in the db to fully test the findOne method
@@ -223,6 +233,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     }
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void findOneForbiddenTest() throws Exception {
         // Create two alert entries in the db to fully test the findOne method
@@ -269,6 +282,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     }
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void findAllActiveTest() throws Exception {
         // Create three alert entries in the db to fully test the findActive search method
@@ -321,6 +337,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     }
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void createTest() throws Exception {
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
@@ -439,6 +458,9 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     }
 
+    // UMD Customization
+    @Ignore("UMD Customization - Test fails in stock DSpace 7.5")
+    // End UMD Customization
     @Test
     public void putTest() throws Exception {
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
Several tests in the "SystemWideAlertRestRepositoryIT.java" class were failing, even in DSpace 7.5.

Using the JUnit "@Ignore" annotation to skip these tests. This will enable us to identify MD-SOAR changes that cause tests to fail more easily by avoiding having stock DSpace test fail as distractors.

Note: These tests are apparently fixed in a later commit, so these changes can likely be removed when MD-SOAR is upgraded to a later DSpace version.

https://umd-dit.atlassian.net/browse/LIBCIR-291
