### PR TITLE
LIBCIR-299. Disable logging crawler activity to solr statistics

### DIFF
--- a/README-mdsoar.md
+++ b/README-mdsoar.md
@@ -111,16 +111,14 @@ Confluence for information about setting up a MacBook to use the Kubernetes
     $ docker buildx build --platform linux/amd64 --builder=kube --push --no-cache -f Dockerfile -t docker.lib.umd.edu/mdsoar-solr:$MDSOAR_TAG .
     ```
 
-### Features
+### MD-SOAR Customizations
 
-* [MdSoarFeatures](dspace/docs/MdsoarFeatures.md) - Summary of MD-SOAR
-  enhancements to base DSpace functionality
-* [MdSoarConfigurationCustomization](dspace/docs/MdSoarConfigurationCustomization.md) -
-  Information about customizing DSpace for MD-SOAR.
-* [docs](dspace/docs) - additional documentation
+MD-SOAR customizations to the stock DSpace code are described in
+[dspace/docs/MdSoarCustomizations](dspace/docs/MdsoarCustomizations.md).
+
+The [dspace/docs](dspace/docs) directory contains additonal documentation
+related to MD-SOAR.
 
 ## License
 
-See the [MDSOAR-LICENSE](MDSOAR-LICENSE.md) file for license rights and limitations
-(Apache 2.0). This lincense only governs the part of code base developed at UMD.
 The DSpace license can be found at <https://github.com/DSpace/DSpace>

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -279,3 +279,11 @@ cc.api.rooturl = https://api.creativecommons.org/rest/1.5
 # See https://github.com/DSpace/DSpace/issues/8543 and
 # https://github.com/DSpace/DSpace/pull/8903
 cc.license.classfilter = recombo, mark, publicdomain
+
+####################
+# USAGE STATISTICS #
+####################
+# Override settings in dspace/config/modules/usage-statistics.cfg
+
+# Disable logging of spiders in solr statistics.
+usage-statistics.logBots = false

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -285,8 +285,8 @@ cc.license.classfilter = recombo, mark, publicdomain
 ####################
 # Override settings in dspace/config/modules/usage-statistics.cfg
 
-# Disable logging of spiders in solr statistics.
-usage-statistics.logBots = false
-
 # Suppress "Statistics" entry in the navbar for non-admins
 usage-statistics.authorization.admin.usage=true
+
+# Disable logging of spiders in solr statistics.
+usage-statistics.logBots = false

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -287,3 +287,6 @@ cc.license.classfilter = recombo, mark, publicdomain
 
 # Disable logging of spiders in solr statistics.
 usage-statistics.logBots = false
+
+# Suppress "Statistics" entry in the navbar for non-admins
+usage-statistics.authorization.admin.usage=true

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -11,16 +11,15 @@ Major customizations have their own documents:
 
 * [MdsoarDOI.md](./MdsoarDOI.md)
 * [SubmissionForm.md](./SubmissionForm.md)
-* Community Themes - See the [umd-lib/medsoar-angular](https://github.com/umd-lib/mdsoar-angular)
+* Community Themes - See the [umd-lib/mdsoar-angular](https://github.com/umd-lib/mdsoar-angular)
   documentation
 
 ## Minor Customizations
 
-The following customizations were made to the DSpace configuration settings in
-the "dspace/config/local.cfg.EXAMPLE" file, to override the default settings in
-the stock DSpace configuration files.
+The following settings were added to the "dspace/config/local.cfg.EXAMPLE" file,
+to override default settings in the stock DSpace configuration files.
 
-* `usage-statistics.logBots` - ("false") Disable logging of spiders/bots in Solr
+* `usage-statistics.logBots` - Disable logging of spiders/bots in Solr
   statistics.
 
 * `usage-statistics.authorization.admin.usage` - Do not show "Statistics" menu

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -1,0 +1,27 @@
+# MD-SOAR Customizations
+
+## Introduction
+
+This document provides information and links to the customizations made to
+the stock DSpace code for MD-SOAR.
+
+## Major Customizations
+
+Major customizations have their own documents:
+
+* [MdsoarDOI.md](./MdsoarDOI.md)
+* [SubmissionForm.md](./SubmissionForm.md)
+* Community Themes - See the [umd-lib/medsoar-angular](https://github.com/umd-lib/mdsoar-angular)
+  documentation
+
+## Minor Customizations
+
+The following customizations were made to the DSpace configuration settings in
+the "dspace/config/local.cfg.EXAMPLE" file, to override the default settings in
+the stock DSpace configuration files.
+
+* `usage-statistics.logBots` - ("false") Disable logging of spiders/bots in Solr
+  statistics.
+
+* `usage-statistics.authorization.admin.usage` - Do not show "Statistics" menu
+  entry in the navbar for non-admins users.


### PR DESCRIPTION
### Disable logging of spiders/bots in Solr statistics

Modified the "dspace/config/local.cfg.EXAMPLE" file, adding the "usage-statistics.logBots" property from the "dspace/config/modules/usage-statistics.cfg" and setting it to "false" so that activity by spiders/bots will not be recorded by the Solr “statistics” core.

This implements the same setting that was in the DSpace 6 MD-SOAR.

### Suppress "Statistics" entry in navbar for non-admins

Modified the "dspace/config/local.cfg.EXAMPLE" file, adding the "usage-statistics.authorization.admin.usage" property from the "dspace/config/modules/usage-statistics.cfg" and setting it to "true" so that the "Statistics" entry in the navbar is suppressed for non-admin users.

This was done to be consistent with the settings in the "umd-lib/k8s-mdsoar" repository

This implements the same setting that was in the DSpace 6 MD-SOAR.

### Added "dspace/docs/MdsoarCustomizations.md" document

Added "dspace/docs/MdsoarCustomizations.md" document to record information about customizations made to DSpace for MD-SOAR.

https://umd-dit.atlassian.net/browse/LIBCIR-299