### PR TITLE
LIBCIR-300. Replaced "DSpace" in email templates with "MD-SOAR".

### DIFF
--- a/dspace/config/emails/change_password
+++ b/dspace/config/emails/change_password
@@ -6,7 +6,7 @@
 ##
 #set($subject = 'Change Password Request')
 #set($phone = ${config.get('mail.message.helpdesk.telephone')})
-To change the password for your DSpace account, please click the link
+To change the password for your MD-SOAR account, please click the link
 below:
 
   ${params[0]}
@@ -19,4 +19,4 @@ If you need assistance with your account, please email
 or call us at ${phone}.
 #end
 
-The DSpace Team
+The MD-SOAR Team

--- a/dspace/config/emails/doi_maintenance_error
+++ b/dspace/config/emails/doi_maintenance_error
@@ -10,7 +10,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = "DSpace: Error ${params[0]} DOI ${params[3]}")
+#set($subject = "MD-SOAR: Error ${params[0]} DOI ${params[3]}")
 
 Date:    ${params[1]}
 

--- a/dspace/config/emails/export_error
+++ b/dspace/config/emails/export_error
@@ -6,7 +6,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'DSpace - The item export you requested was not completed.')
+#set($subject = 'MD-SOAR - The item export you requested was not completed.')
 The item export you requested was not completed, due to the following reason:
  ${params[0]}
 
@@ -15,5 +15,5 @@ For more information you may contact your system administrator:
 
 
 
-The DSpace Team
+The MD-SOAR Team
 

--- a/dspace/config/emails/export_success
+++ b/dspace/config/emails/export_success
@@ -5,7 +5,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'DSpace - Item export requested is ready for download')
+#set($subject = 'MD-SOAR - Item export requested is ready for download')
 The item export you requested from the repository is now ready for download.
 
 You may download the compressed file using the following link:
@@ -14,5 +14,5 @@ ${params[0]}
 This file will remain available for at least ${params[1]} hours.
 
 
-The DSpace Team
+The MD-SOAR Team
 

--- a/dspace/config/emails/flowtask_notify
+++ b/dspace/config/emails/flowtask_notify
@@ -7,7 +7,7 @@
 ## {4}  Task result
 ## {5}  Workflow action taken
 ##
-#set($subject = 'DSpace: Curation Task Report')
+#set($subject = 'MD-SOAR: Curation Task Report')
 
 Title:         ${params[0]}
 Collection:    ${params[1]}
@@ -20,4 +20,4 @@ ${params[4]}
 
 Action taken on the submission: ${params[5]}
 
-DSpace
+MD-SOAR

--- a/dspace/config/emails/harvesting_error
+++ b/dspace/config/emails/harvesting_error
@@ -8,7 +8,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'DSpace: Harvesting Error')
+#set($subject = 'MD-SOAR: Harvesting Error')
 Collection ${params[0]} failed on harvest:
 
 Date:       	${params[1]}

--- a/dspace/config/emails/internal_error
+++ b/dspace/config/emails/internal_error
@@ -10,7 +10,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'DSpace: Internal Server Error')
+#set($subject = 'MD-SOAR: Internal Server Error')
 An internal server error occurred on ${params[0]}:
 
 Date:       ${params[1]}

--- a/dspace/config/emails/register
+++ b/dspace/config/emails/register
@@ -6,7 +6,7 @@
 ##
 #set($subject = "${config.get('dspace.name')} Account Registration")
 #set($phone = ${config.get('mail.message.helpdesk.telephone')})
-To complete registration for a DSpace account, please click the link
+To complete registration for an MD-SOAR account, please click the link
 below:
 
   ${params[0]}
@@ -19,4 +19,4 @@ If you need assistance with your account, please email
 or call us at ${phone}.
 #end
 
-The DSpace Team
+The MD-SOAR Team

--- a/dspace/config/emails/registration_notify
+++ b/dspace/config/emails/registration_notify
@@ -8,7 +8,7 @@
 ##
 ## See org.dspace.core.Email for information on the format of this file.
 ##
-#set($subject = 'DSpace: Registration Notification')
+#set($subject = 'MD-SOAR: Registration Notification')
 
 A new user has registered on ${params[0]} at ${params[1]}:
 

--- a/dspace/config/emails/submit_archive
+++ b/dspace/config/emails/submit_archive
@@ -4,13 +4,13 @@
 ## {1}  Name of collection
 ## {2}  handle
 ##
-#set($subject = 'DSpace: Submission Approved and Archived')
+#set($subject = 'MD-SOAR: Submission Approved and Archived')
 
 You submitted: ${params[0]}
 
 To collection: ${params[1]}
 
-Your submission has been accepted and archived in DSpace,
+Your submission has been accepted and archived in MD-SOAR,
 and it has been assigned the following identifier:
 ${params[2]}
 
@@ -18,4 +18,4 @@ Please use this identifier when citing your submission.
 
 Many thanks!
 
-DSpace
+MD-SOAR

--- a/dspace/config/emails/submit_reject
+++ b/dspace/config/emails/submit_reject
@@ -6,7 +6,7 @@
 ## {3}  Reason for the rejection
 ## {4}  Link to 'My DSpace' page
 ##
-#set($subject = 'DSpace: Submission Rejected')
+#set($subject = 'MD-SOAR: Submission Rejected')
 
 You submitted: ${params[0]}
 
@@ -18,6 +18,6 @@ with the following explanation:
 ${params[3]}
 
 Your submission has not been deleted.  You can access it from your
-"My DSpace" page: ${params[4]}
+"My MD-SOAR" page: ${params[4]}
 
-DSpace
+MD-SOAR

--- a/dspace/config/emails/submit_task
+++ b/dspace/config/emails/submit_task
@@ -6,7 +6,7 @@
 ## {3}  Description of task
 ## {4}  link to 'my DSpace' page
 ##
-#set($subject = 'DSpace: You have a new task')
+#set($subject = 'MD-SOAR: You have a new task')
 
 A new item has been submitted:
 
@@ -16,9 +16,9 @@ Submitted by: ${params[2]}
 
 ${params[3]}
 
-To claim this task, please visit your "My DSpace"
+To claim this task, please visit your "My MD-SOAR"
 page:  ${params[4]}
 
 Many thanks!
 
-DSpace
+MD-SOAR

--- a/dspace/config/emails/subscriptions_content
+++ b/dspace/config/emails/subscriptions_content
@@ -2,9 +2,9 @@
 ##
 ## Parameters: {0} Collections updates
 ##             {1} Communities updates
-#set($subject = 'DSpace Subscription')
+#set($subject = 'MD-SOAR Subscription')
 
-This email is sent from DSpace based on the chosen subscription preferences.
+This email is sent from MD-SOAR based on the chosen subscription preferences.
 
 Communities
 -----------

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -52,7 +52,7 @@ dspace.server.url = ${dspace.baseUrl}/server
 dspace.ui.url = http://localhost:4000
 
 # Name of the site
-dspace.name = Maryland Shared Open Access Repository
+dspace.name = MD-SOAR
 
 # Assetstore configurations have moved to config/modules/assetstore.cfg
 # and config/spring/api/bitstore.xml.
@@ -141,7 +141,7 @@ db.schema = public
 #feedback.recipient = dspace-help@myu.edu
 
 # General site administration (Webmaster) e-mail
-#mail.admin = dspace-help@myu.edu
+mail.admin = mdsoar-help@umd.edu
 
 # Helpdesk E-mail
 #mail.helpdesk = ${mail.admin}

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -16,6 +16,8 @@ Major customizations have their own documents:
 
 ## Minor Customizations
 
+### dspace/config/local.cfg.EXAMPLE
+
 The following settings were added to the "dspace/config/local.cfg.EXAMPLE" file,
 to override default settings in the stock DSpace configuration files.
 
@@ -24,3 +26,10 @@ to override default settings in the stock DSpace configuration files.
 
 * `usage-statistics.authorization.admin.usage` - Do not show "Statistics" menu
   entry in the navbar for non-admins users.
+
+### Email Templates
+
+The email templates in the "dspace/config/emails/" directory were modified to
+replace "DSpace" with "MD-SOAR".
+
+


### PR DESCRIPTION
Changed "DSpace" in email templates to "MD-SOAR".

Also adjusted properties in the "dspace/config/local.cfg.EXAMPLE" file used in email templates to match those in the Kubernetes production.

https://umd-dit.atlassian.net/browse/LIBCIR-300
