### PR TITLE
LIBCIR-315. Enable administrators to impersonate non-admins

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -270,6 +270,7 @@ crosswalk.dissemination.DataCite.publisher = Maryland Shared Open Access Reposit
 ############################
 # UI-RELATED CONFIGURATION #
 ############################
+webui.user.assumelogin = true
 
 # Creative Commons settings
 cc.api.rooturl = https://api.creativecommons.org/rest/1.5

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -21,6 +21,9 @@ Major customizations have their own documents:
 The following settings were added to the "dspace/config/local.cfg.EXAMPLE" file,
 to override default settings in the stock DSpace configuration files.
 
+* `webui.user.assumelogin` - Enabled administrators to impersonate non-admin
+    users
+
 * `usage-statistics.logBots` - Disable logging of spiders/bots in Solr
   statistics.
 


### PR DESCRIPTION
Set "webui.user.assumelogin" property to "true" to allow administrators to impersonate non-admins (as is allowed in DSpace 6).

Added documentation.

https://umd-dit.atlassian.net/browse/LIBCIR-315
