### PR TITLE
LIBCIR-314. Modified configuration to include "Browse by Type"

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -256,6 +256,15 @@ mail.admin = mdsoar-help@umd.edu
 # Maximum size of a multipart request (i.e. max total size of all files in one request)
 #spring.servlet.multipart.max-request-size = 512MB
 
+########################
+# BROWSE CONFIGURATION #
+########################
+webui.browse.index.1 = dateissued:item:dateissued
+webui.browse.index.2 = title:item:title
+webui.browse.index.3 = author:metadata:dc.contributor.author\,dc.creator:text
+webui.browse.index.4 = subject:metadata:dc.coverage.spatial\,dc.coverage.temporal\,dc.coverage\,dc.subject.classification\,dc.subject.*\,dc.subject\,dcterms.temporal\,dcterms.subject\,dcterms.spatial\,dcterms.coverage:text
+webui.browse.index.5 = type:metadata:dc.format\,dc.genre\,dc.type:text
+
 #####################
 # DOI CONFIGURATION #
 #####################

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -30,6 +30,9 @@ to override default settings in the stock DSpace configuration files.
 * `usage-statistics.authorization.admin.usage` - Do not show "Statistics" menu
   entry in the navbar for non-admins users.
 
+* Modified `webui.browse.index.<n>` entries, adding the ability to browse by
+  "Type".
+
 ### Email Templates
 
 The email templates in the "dspace/config/emails/" directory were modified to


### PR DESCRIPTION
Modified the "webui.browse.index" entries to match those in DSpace 6 MD-SOAR, including adding an additional entry to enable "Browse by Type".

Added information about the customization to the
"MdsoarCustomizations.md" file.

https://umd-dit.atlassian.net/browse/LIBCIR-314
