### PR TITLE
LIBCIR-308. Enabled "eperson.subscription.onlynew" property

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -300,3 +300,9 @@ usage-statistics.authorization.admin.usage=true
 
 # Disable logging of spiders in solr statistics.
 usage-statistics.logBots = false
+
+######################
+# MISC CONFIGURATION #
+######################
+# Only send subscription emails for new items
+eperson.subscription.onlynew = true

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -21,8 +21,7 @@ Major customizations have their own documents:
 The following settings were added to the "dspace/config/local.cfg.EXAMPLE" file,
 to override default settings in the stock DSpace configuration files.
 
-* `webui.user.assumelogin` - Enabled administrators to impersonate non-admin
-    users
+* `eperson.subscription.onlynew` - Only send subscription emails for new items
 
 * `usage-statistics.logBots` - Disable logging of spiders/bots in Solr
   statistics.
@@ -32,6 +31,9 @@ to override default settings in the stock DSpace configuration files.
 
 * Modified `webui.browse.index.<n>` entries, adding the ability to browse by
   "Type".
+
+* `webui.user.assumelogin` - Enabled administrators to impersonate non-admin
+    users
 
 ### Email Templates
 


### PR DESCRIPTION
Added "eperson.subscription.onlynew", setting it to true, so that subscription emails are only sent out for new items (as opposed to both new and modified items).

Added property to "MdsoarCustomizations.md" and reorganized property list to be in alphabetical order.

https://umd-dit.atlassian.net/browse/LIBCIR-308

