### PR TITLE
LIBCIR-304. Added Google Analytics 4 configuration properties

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -276,6 +276,14 @@ identifier.doi.mintRandom = true
 identifier.doi.namespaceseparator = m2
 crosswalk.dissemination.DataCite.publisher = Maryland Shared Open Access Repository
 
+##################################
+# GOOGLE ANALYTICS CONFIGURATION #
+##################################
+google.analytics.key =
+google.analytics.buffer = 256
+google.analytics.cron = 0 0/5 * * * ?
+google.analytics.api-secret =
+
 ############################
 # UI-RELATED CONFIGURATION #
 ############################

--- a/dspace/docs/DockerDevelopmentEnvironment.md
+++ b/dspace/docs/DockerDevelopmentEnvironment.md
@@ -31,12 +31,24 @@ main branch for MD-SOAR development.
     $ cp dspace/config/local.cfg.EXAMPLE dspace/config/local.cfg
     ```
 
-    If testing DOI generation, edit the file, and fill out the following fields:
+    The following functionality is not enabled by default in the local
+    development environment:
 
-    * identifier.doi.user: `DEMO.UMD`
-    * identifier.doi.password: <See the `identifier.doi.password` property
-                                in the “mdsoar-local-secrets-cfg” secret in the
-                                Kubernetes configuration>
+    * DataCite DOI generation
+
+      To enable DOI generation, fill out the following properties from the
+      "DRUM/MD-SOAR DataCite Credentials" note in LastPass:
+
+        * identifier.doi.user
+        * identifier.doi.password
+
+    * Google Analytics
+
+      To enable Google Analytics, fill out the following properties from the
+      "MD-SOAR Google Analytics" note in LastPass:
+
+        * google.analytics.key
+        * google.analytics.api-secret
 
 4) Retrieve a database dump from Kubernetes. The following steps work with
    both DSpace 6 and DSpace 7 databases:

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -40,4 +40,16 @@ to override default settings in the stock DSpace configuration files.
 The email templates in the "dspace/config/emails/" directory were modified to
 replace "DSpace" with "MD-SOAR".
 
+### Google Analytics
 
+MD-SOAR uses stock DSpace Google Analytics 4 functionality to track site usage,
+including file/bitstream downloads (see
+<https://wiki.lyrasis.org/display/DSDOC7x/DSpace+Google+Analytics+Statistics>).
+
+In order to track file downloads, the following properties must be set in
+the "dspace/config/local.cfg" file:
+
+* google.analytics.key
+* google.analytics.buffer
+* google.analytics.cron
+* google.analytics.api-secret


### PR DESCRIPTION
Added “Google Analytics Configuration” section to
“dspace/config/local.cfg.EXAMPLE”, leaving the "google.analytics.key" and "google.analytics.api-secret" properties blank because we probably don’t want analytics from the local development environment by default.

Added information about Google Analytics to the
“dspace/docs/MdsoarCustomizations.md” and
“dspace/docs/DockerDevelopmentEnvironment.md” documentation.

https://umd-dit.atlassian.net/browse/LIBCIR-304
