### PR TITLE
LIBCIR-326. webui.browse.link CrossLinks: Fix for multiple exact matches

### DIFF
--- a/dspace/modules/additions/src/main/java/org/dspace/browse/CrossLinks.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/browse/CrossLinks.java
@@ -1,0 +1,123 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.browse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * Class to represent the configuration of the cross-linking between browse
+ * pages (for example, between the author name in one full listing to the
+ * author's list of publications).
+ *
+ * @author Richard Jones
+ */
+
+ // Note: The changes in this class were submitted to the upstream DSpace in
+ // https://github.com/DSpace/DSpace/pull/8936
+public class CrossLinks {
+    /**
+     * a map of the desired links
+     */
+    private Map<String, String> links = new HashMap<>();
+
+    /**
+     * Construct a new object which will obtain the configuration for itself.
+     *
+     * @throws BrowseException if browse error
+     */
+    public CrossLinks()
+        throws BrowseException {
+        int i = 1;
+        while (true) {
+            String field = "webui.browse.link." + i;
+            ConfigurationService configurationService
+                    = DSpaceServicesFactory.getInstance().getConfigurationService();
+            String config = configurationService.getProperty(field);
+            if (config == null) {
+                break;
+            }
+
+            String[] parts = config.split(":");
+            if (parts.length != 2) {
+                throw new BrowseException("Invalid configuration for " + field + ": " + config);
+            }
+            links.put(parts[1], parts[0]);
+            i++;
+        }
+    }
+
+    /**
+     * Is there a link for the given canonical form of metadata (i.e. schema.element.qualifier)?
+     *
+     * @param metadata the metadata to check for a link on
+     * @return true/false
+     */
+    public boolean hasLink(String metadata) {
+        return findLinkType(metadata) != null;
+    }
+
+    /**
+     * Is there a link for the given browse name (eg 'author')
+     * @param browseIndexName
+     * @return true/false
+     */
+    public boolean hasBrowseName(String browseIndexName) {
+        return links.containsValue(browseIndexName);
+    }
+
+    /**
+     * Get the type of link that the bit of metadata has.
+     *
+     * @param metadata the metadata to get the link type for
+     * @return type
+     */
+    public String getLinkType(String metadata) {
+        return findLinkType(metadata);
+    }
+
+    /**
+     * Get full map of field->indexname link configurations
+     * @return
+     */
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    /**
+     * Find and return the browse name for a given metadata field.
+     * If the link key contains a wildcard eg dc.subject.*, it should
+     * match dc.subject.other, etc.
+     * @param metadata
+     * @return
+     */
+    public String findLinkType(String metadata) {
+        // Resolve wildcards properly, eg. dc.subject.other matches a configuration for dc.subject.*
+        for (String key : links.keySet()) {
+            if (null != key && key.endsWith(".*")) {
+                // A substring of length-1, also substracting the wildcard should work as a "startsWith"
+                // check for the field eg. dc.subject.* -> dc.subject is the start of dc.subject.other
+                if (null != metadata && metadata.startsWith(key.substring(0, key.length() - 1 - ".*".length()))) {
+                    return links.get(key);
+                }
+            } else {
+                // Exact match, if the key field has no .* wildcard
+                if (links.containsKey(metadata)) {
+                    // UMD Customization
+                    return links.get(metadata);
+                    // End UMD Customization
+                }
+            }
+        }
+        // No match
+        return null;
+    }
+}

--- a/dspace/modules/additions/src/test/java/org/dspace/browse/CrossLinksTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/browse/CrossLinksTest.java
@@ -1,0 +1,106 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.browse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for {@link CrossLinks}
+ */
+
+// Note: This class was submitted to the upstream DSpace in
+// https://github.com/DSpace/DSpace/pull/8936
+public class CrossLinksTest extends AbstractDSpaceTest {
+    protected ConfigurationService configurationService;
+
+
+    @Before
+    public void setUp() {
+      configurationService = new DSpace().getConfigurationService();
+    }
+
+    @Test
+    public void testFindLinkType_Null() throws Exception {
+        CrossLinks crossLinks = new CrossLinks();
+        assertNull(crossLinks.findLinkType(null));
+    }
+
+    @Test
+    public void testFindLinkType_NoMatch() throws Exception {
+        CrossLinks crossLinks = new CrossLinks();
+        String metadataField = "foo.bar.baz.does.not.exist";
+        assertNull(crossLinks.findLinkType(metadataField));
+    }
+
+    @Test
+    public void testFindLinkType_WildcardMatch() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        CrossLinks crossLinks = new CrossLinks();
+
+        String metadataField = "dc.contributor.author";
+        assertEquals("author",crossLinks.findLinkType(metadataField));
+    }
+
+    @Test
+    public void testFindLinkType_SingleExactMatch_Author() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.author");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+    }
+
+    @Test
+    public void testFindLinkType_SingleExactMatch_Type() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "type:dc.genre");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+    }
+
+    @Test
+    public void testFindLinkType_MultipleExactMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.author");
+        configurationService.setProperty("webui.browse.link.2", "type:dc.genre");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+    }
+
+    @Test
+    public void testFindLinkType_MultipleWildcardMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        configurationService.setProperty("webui.browse.link.2", "subject:dc.subject.*");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("subject",crossLinks.findLinkType("dc.subject.lcsh"));
+    }
+
+    @Test
+    public void testFindLinkType_MultiplExactAndWildcardMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        configurationService.setProperty("webui.browse.link.2", "subject:dc.subject.*");
+        configurationService.setProperty("webui.browse.link.3", "type:dc.genre");
+        configurationService.setProperty("webui.browse.link.4", "dateissued:dc.date.issued");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("subject",crossLinks.findLinkType("dc.subject.lcsh"));
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+        assertEquals("dateissued",crossLinks.findLinkType("dc.date.issued"));
+    }
+}


### PR DESCRIPTION
Fixes an issue in the "CrossLinks" class to enable multiple "webui.browse.link" configuration entries with exact matches to different indexes to be processed properly.

This fixes a stock DSpace bug. The associated DSpace issue is

https://github.com/DSpace/DSpace/issues/8935

and a change similar to this one (except in the "dspace-api" module) was submitted in a pull request:

https://github.com/DSpace/DSpace/pull/8936

https://umd-dit.atlassian.net/browse/LIBCIR-326
