### PR TITLE
LIBCIR-322. Added CrossLinks configuration for MD-SOAR

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -265,6 +265,25 @@ webui.browse.index.3 = author:metadata:dc.contributor.author\,dc.creator:text
 webui.browse.index.4 = subject:metadata:dc.coverage.spatial\,dc.coverage.temporal\,dc.coverage\,dc.subject.classification\,dc.subject.*\,dc.subject\,dcterms.temporal\,dcterms.subject\,dcterms.spatial\,dcterms.coverage:text
 webui.browse.index.5 = type:metadata:dc.format\,dc.genre\,dc.type:text
 
+# CrossLinks configuration
+# See "webui.browse.link" section in dspace.cfg
+#
+# Wild cards are allowed, but multiple values per entry are not
+
+# Author
+webui.browse.link.1 = author:dc.contributor.author
+webui.browse.link.2 = author:dc.creator
+
+# Subject
+webui.browse.link.3 = subject:dc.subject.*
+webui.browse.link.4 = subject:dc.coverage.*
+
+# Type
+webui.browse.link.5 = type:dc.genre
+webui.browse.link.6 = type:dc.type
+webui.browse.link.7 = type:dc.format
+webui.browse.link.8 = type:dcterms.format
+
 #####################
 # DOI CONFIGURATION #
 #####################

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -9,10 +9,11 @@ the stock DSpace code for MD-SOAR.
 
 Major customizations have their own documents:
 
-* [DataCiteDOI.md](./DataCiteDOI.md)
-* [SubmissionForm.md](./SubmissionForm.md)
 * Community Themes - See the [umd-lib/mdsoar-angular](https://github.com/umd-lib/mdsoar-angular)
   documentation
+* [DataCiteDOI.md](./DataCiteDOI.md)
+* [SimpleItemPage.md](./SimpleItemPage.md)
+* [SubmissionForm.md](./SubmissionForm.md)
 
 ## Minor Customizations
 

--- a/dspace/docs/SimpleItemPage.md
+++ b/dspace/docs/SimpleItemPage.md
@@ -1,0 +1,135 @@
+# Simple Item Page
+
+## Introduction
+
+This page describes the customizations made to the MD-SOAR "simple item"
+page display.
+
+## Changes to DSpace 6 MD-SOAR
+
+The following changes were made when migrating the DSpace 6 MD-SOAR
+configuration to DSpace 7, largely based on discrepancies between the
+specifications in the Jira issues and the implementation in the
+DSpace 6 MD-SOAR.
+
+### "Author/Creator" Field
+
+The original specification in LIBCIR-78 lists using both the
+"dc.contributor.author" and "dc.creator" metadata values for the
+"Author/Creator" field.
+
+When the "Author/Creator ORCID" field was added in LIBCIR-263, the "dc.creator"
+field was removed from the "Author/Creator" field, likely in error (as the
+"Author/Creator ORCID" uses the similarly named, but different,
+"dcterms.creator" metadata value).
+
+In DSpace 7 MD-SOAR, the "Author/Creator" field uses both the
+"dc.contributor.author" and "dc.creator" metadata values.
+
+### "Type of Work" Field
+
+In the DSpace 6 MD-SOAR, the "Type of Work" field would display the
+"dc.format.extent" metadata values. As these field values are usually simple
+numbers such as "176" or file metadata information such as
+"File Size: 100689 Bytes", they do not seem to be genuine "types of work".
+
+This behavior is likely a result of an error in the field handling logic
+where the "dc.format" metadata is (correctly) included, but descendant metadata
+such as "dc.format.extent" was not excluded.
+
+In DSpace 7 MD-SOAR, the "dc.format.extent" metadata in *not* included in the
+"Type of Work" field.
+
+Additionally, the "Type of Work" field was not hyperlinked ("crosslinked") to
+the "Browsing by Type" index in DSpace 6 MD-SOAR, but is hyperlinked in
+DSpace 7 MD-SOAR.
+
+### "Metadata" Field
+
+The "Metadata" field in the left sidebar, which provided a
+"Show full item record" hyperlink to the "full item" page, was replaced
+(without a "Metadata" label) by the "Full item page" button in
+Dspace 7 MD-SOAR, to better conform to the DSpace 7 look-and-feel.
+
+## Simple Item Page Layout
+
+### Left sidebar
+
+* Thumbnail (No label)
+  * `<From the DSpace object>`
+* Files
+  * `<Links to all files in the DSpace object>`
+* Permanent Link
+  * dc.identifier.uri
+* Collections
+  * `<From DSpace>`
+* Metadata (No Label)
+  * `<Link to “full item record” page>`
+  * **Note:** DSpace 7 provides a "Full item page" button, which is used in
+    place of the "Metadata" label and link.
+
+### Center of Page
+
+* Author/Creator
+  * dc.creator
+  * dc.contributor.author
+* Author/Creator ORCID
+  * dcterms.creator
+* Date
+  * dc.date
+  * dc.date.issued
+  * dc.date.created
+  * dc.date.copyright
+  * dctermscreated
+  * dctermsdate
+  * dcterms.dateAccepted
+  * dcterms.dateCopyrighted
+* Type of Work
+  * dc.genre
+  * dc.type
+  * dc.format
+  * dcterms.format
+* Department
+  * dc.contributor.department
+* Program
+  * dc.contributor.program
+* Citation of Original Publication
+  * dc.identifier.citation
+  * dcterms.bibiographicCitation
+* Rights
+  * dc.rights
+  * dcterms.accessRights
+* Subjects
+  * dc.subject
+  * dc.subject.lcsh
+  * dc.subject.mesh
+  * dc.coverage.temporal
+  * dc.coverage.spatial
+* Abstract
+  * dc.description.abstract
+
+## Field Value Hyperlinks/CrossLinks
+
+The following fields display their values with hyperlinks:
+
+* Files
+* Permanent Link
+* Collections
+* Author/Creator
+* Author/Creator ORCID
+* Type of Work
+* Subjects
+
+The "Date" field could potentially be hyperlinked, but was not in
+DSpace 6 MD-SOAR. In DSpace 7 MD-SOAR, it was not hyperlinked (crosslinked)
+because the "Date" field includes a number of date-related metadata values in
+addition to the stock DSpace "dc.date.issued" metadata value ("dc.date.created",
+"dc.date.copyright", etc.) and they would all be linked to the "dateissued"
+browse index. Some of the dates returned by the metadata properties include
+ranges, i.e. "1984-2001", which do not work with the browse index.
+
+The crosslinks (and which index they connect to) is controlled by the
+"webui.browse.link.\<n>" entries in the "dspace/config/local.cfg" file.
+
+Each "webui.browse.link" entry must specify an existing index in the
+"webui.browse.index" list to link to.


### PR DESCRIPTION
Added configuration to "local.cfg.EXAMPLE" to configure "crosslinks" for the simple item page, so that specific fields will be hyperlinked to their appropriate "browse by" search page.

Added "SimpleItemPage.md" to record MD-SOAR customizations to the "simple item" page.

Updated "MdsoarCustomizations.md" to link to the "SimpleItemPage.md" and rearranged the links to be in alphabetical order.

https://umd-dit.atlassian.net/browse/LIBCIR-322
