### PR TITLE
LIBCIR-297. Initial implementation of Solr autosuggest

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -303,6 +303,29 @@ google.analytics.buffer = 256
 google.analytics.cron = 0 0/5 * * * ?
 google.analytics.api-secret =
 
+##############################
+# SOLR SUGGEST CONFIGURATION #
+##############################
+# Override settings in dspace/config/modules/authority.cfg
+
+# Enable choice authority plugins for Solr autosuggest
+plugin.named.org.dspace.content.authority.ChoiceAuthority = \
+  edu.umd.lib.dspace.content.authority.SuggestChoiceAuthority = SolrFormatAuthority, \
+  edu.umd.lib.dspace.content.authority.SuggestChoiceAuthority = SolrSubjectAuthority
+
+# Configuration settings for Solr autosuggest
+solr.suggest.server=${solr.server}/${solr.multicorePrefix}search
+
+# "Format" submission form field
+choices.plugin.dc.genre = SolrFormatAuthority
+choices.presentation.dc.genre = suggest
+choices.SolrFormatAuthority.dictionary = formatSuggest
+
+# "Subject Keywords" submission form field
+choices.plugin.dc.subject = SolrSubjectAuthority
+choices.presentation.dc.subject = suggest
+choices.SolrSubjectAuthority.dictionary = subjectSuggest
+
 ############################
 # UI-RELATED CONFIGURATION #
 ############################

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -9,11 +9,12 @@ the stock DSpace code for MD-SOAR.
 
 Major customizations have their own documents:
 
-* Community Themes - See the [umd-lib/mdsoar-angular](https://github.com/umd-lib/mdsoar-angular)
-  documentation
 * [DataCiteDOI.md](./DataCiteDOI.md)
 * [SimpleItemPage.md](./SimpleItemPage.md)
+* [SolrAutosuggest.md](./SolrAutosuggest.md)
 * [SubmissionForm.md](./SubmissionForm.md)
+* Community Themes - See the [umd-lib/mdsoar-angular](https://github.com/umd-lib/mdsoar-angular)
+  documentation
 
 ## Minor Customizations
 

--- a/dspace/docs/SolrAutosuggest.md
+++ b/dspace/docs/SolrAutosuggest.md
@@ -1,0 +1,106 @@
+# Solr Autosuggest
+
+## Introduction
+
+This page describes the Solr autosuggest functionality for MD-SOAR.
+
+## Background
+
+This functionality is implemented as a "ChoiceAuthority" plugin based on the
+stock DSpace authority control functionality. See
+<https://wiki.lyrasis.org/display/DSPACE/Authority+Control+of+Metadata+Values>
+for more information.
+
+This implementation only performs "choice management", i.e., it generates a
+list of possible choices. It does *not* implement "authority control", as no
+authority key is provided with the chosen value.
+
+The suggestions are provided by the Solr "suggester" functionality. See
+<https://solr.apache.org/guide/8_11/suggester.html> for more information.
+
+## Behavior
+
+Provides suggestions for the "Format" (dc.genre) and "Subject Keywords"
+(dc.subject) fields on the submission form from the "search" Solr core, based
+on the text typed in the fields by the user.
+
+Both the "Format" and "Subject Keywords" fields are "open", in that the user
+may type in any value (i.e., is not required to choose one of the suggested
+values).
+
+## Configuration
+
+### Solr configuration
+
+The Solr "search" core is configured with two "suggester" search components in
+the `dspace/solr/search/conf/solrconfig.xml` file.
+
+The "formatSuggest" suggester looks up entries in the "dc.genre" field, while
+the "subjectSuggest" suggester looks up entries in the "dc.subject" field. Both
+suggesters use the "BlendedInfixLookupFactory" as the lookup implementation
+as it seems to give the best results (compared to the
+"AnalyzingInfixLookupFactory" used in DSpace 6 MD-SOAR which seemed to give
+duplicate suggestions).
+
+A "suggest" request handler is also added to the Solr "search" core for use in
+retrieving suggestions. This can be tested directly using `curl`. For example,
+to search the "formatSuggest" suggester (i.e., the "dc.genre" field) for entries
+with "book":
+
+```zsh
+$ curl 'http://localhost:8983/solr/search/suggest?indent=true&q.op=OR&suggest.dictionary=formatSuggest&suggest.q=book&wt=json&highlight=false'
+```
+
+**Note:** If applying this configuration to an existing Solr "search" core, a
+Solr reindex is necessary for suggestions to actually be generated.
+
+### DSpace configuration
+
+Two files require configuration for this functionality:
+
+* `dspace/modules/additions/src/main/resources/spring/spring-dspace-addon-umd-custom-services.xml`
+* `dspace/config/local.cfg`
+
+The `spring-dspace-addon-umd-custom-services.xml` file uses Spring to configure
+the "edu.umd.lib.dspace.content.authority.SuggestService" interface with the
+"edu.umd.lib.dspace.content.authority.SolrSuggestService" implementation.
+
+The `local.cfg` configures the autosuggest functionality for use
+with the "Format" and "Subject Keywords" submission form fields. The
+`dspace/config/local.cfg.EXAMPLE` contains the appropriate configuration:
+
+```text
+# Configuration settings for Solr autosuggest
+solr.suggest.server=${solr.server}/${solr.multicorePrefix}search
+
+# "Format" submission form field
+choices.plugin.dc.genre = SolrFormatAuthority
+choices.presentation.dc.genre = suggest
+choices.SolrFormatAuthority.dictionary = formatSuggest
+
+# "Subject Keywords" submission form field
+choices.plugin.dc.subject = SolrSubjectAuthority
+choices.presentation.dc.subject = suggest
+choices.SolrSubjectAuthority.dictionary = subjectSuggest
+```
+
+The `solr.suggest.server` property is used to define the Solr server and core
+to use for the suggestion lookups. The same Solr server (and core) is used for
+both suggestion lookups.
+
+The `choices.plugin.<SCHEMA.ELEMENT>` and
+`choices.presentation.<SCHEMA.ELEMENT>` properties are used to configure the
+form submission field to use the autosuggest functionality. See
+<https://wiki.lyrasis.org/display/DSPACE/Authority+Control+of+Metadata+Values>.
+
+The `choices.<AUTHORITY>.dictionary` properties are used by the
+"SolrSuggestService" class to configure the Solr suggester to use for
+each field.
+
+The DSpace suggestion endpoint can be tested directly using `curl`. For example,
+to search the "formatSuggest" suggester (i.e., the "dc.genre" field) for entries
+with "book":
+
+```zsh
+$ curl 'http://localhost:8080/server/api/submission/vocabularies/SolrFormatAuthority/entries?filter=book&exact=false'
+```

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SolrSuggestService.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SolrSuggestService.java
@@ -1,0 +1,203 @@
+package edu.umd.lib.dspace.content.authority;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.dspace.content.authority.Choice;
+import org.dspace.content.authority.ChoiceAuthority;
+import org.dspace.content.authority.Choices;
+import org.dspace.service.impl.HttpConnectionPoolService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * SuggestService implementation that uses the Solr "suggester" functionality
+ * to generate suggestions.
+ */
+public class SolrSuggestService implements SuggestService {
+    private static final Logger log = LogManager.getLogger(SolrSuggestService.class);
+
+    @Inject @Named("solrHttpConnectionPoolService")
+    private HttpConnectionPoolService httpConnectionPoolService;
+
+    protected final ConfigurationService configurationService
+        = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+
+    /**
+     * The ChoiceAuthority to use in formatting Choice results
+     */
+    protected ChoiceAuthority choiceAuthority;
+
+    /**
+     * Cached instance of the SolrClient
+     */
+    protected SolrClient solr = null;
+
+    /**
+     * The "suggest dictionary" associated with this service.
+     */
+    protected String suggestDictionary;
+
+    protected  SolrSuggestService() {
+    }
+
+    @Override
+    public Choices search(String queryText, int start, int limit) {
+        Choices result;
+        try {
+            int max = 0;
+            boolean hasMore = false;
+
+            SolrQuery solrQuery = new SolrQuery();
+            solrQuery.setRequestHandler("/suggest");
+            solrQuery.setParam("suggest", "true");
+            solrQuery.setParam("suggest.dictionary", suggestDictionary);
+            solrQuery.setParam("suggest.q", queryText);
+
+            QueryResponse searchResponse = search(solrQuery);
+
+            Map<String, List<String>> suggestedTerms = searchResponse.getSuggesterResponse().getSuggestedTerms();
+            List<String> suggestions = suggestedTerms.get(suggestDictionary);
+            List<Choice> choices = new ArrayList<>();
+            for (String suggestion: suggestions) {
+                Choice choice = choiceAuthority.getChoice(suggestion, null);
+                choices.add(choice);
+            }
+
+            int confidence;
+            if (choices.isEmpty()) {
+                confidence = Choices.CF_NOTFOUND;
+            } else if (choices.size() == 1) {
+                confidence = Choices.CF_UNCERTAIN;
+            } else {
+                confidence = Choices.CF_AMBIGUOUS;
+            }
+
+            result = new Choices(choices.toArray(new Choice[choices.size()]), start,
+                                hasMore ? max : choices.size() + start, confidence, hasMore);
+        } catch (SolrServerException | IOException e) {
+            log.error(
+                "Error while retrieving authority values {" +
+                "suggestDictionary: " + suggestDictionary +
+                ", text: '" + queryText +
+                "'}",
+                e
+            );
+            result = new Choices(true);
+        }
+        return result;
+    }
+
+    @Override
+    public void configure(String authorityName, ChoiceAuthority choiceAuthority) {
+        this.choiceAuthority = choiceAuthority;
+        suggestDictionary = configurationService.getProperty("choices." + authorityName + ".dictionary");
+    }
+
+    /**
+     * Returns the QueryResponse from Solr for the given SolrQuery.
+     *
+     * @param solrQuery the SolrQuery to perform
+     * @return the QueryResponse from Solr, or null if an error occurs.
+     */
+    protected QueryResponse search(SolrQuery solrQuery)
+            throws SolrServerException, MalformedURLException, IOException {
+        SolrClient solrClient = getSolrClient();
+        return querySolr(solrClient, solrQuery);
+    }
+
+    /**
+     * Returns a SolrClient, returning null if a SolrClient could not be created.
+     *
+     * @return a SolrClient, or null if a SolrClient could not be created.
+     */
+    protected SolrClient getSolrClient() {
+        if (solr == null) {
+            String solrServerUrl = getSolrServerUrl();
+            solr = configureSolrClient(solrServerUrl);
+        }
+
+        return solr;
+    }
+
+
+    /**
+     * Performs the given SolrQuery against the given SolrCient, returning
+     * either the QueryResponse, or null if an error occurs.
+     *
+     * @param solrClient the SolrClient to query
+     * @param solrQuery the SolrQuery to perform
+     * @return a QueryResponse, or null if an error occurs.
+     */
+    protected QueryResponse querySolr(SolrClient solrClient, SolrQuery solrQuery)
+            throws SolrServerException, IOException {
+        if (solrClient == null ) {
+            return null;
+        }
+        return solrClient.query(solrQuery);
+    }
+
+    /**
+     * Returns the base Solr URL to use in performing queries, or null if
+     * the "solr.suggest.server" property is not provided.
+     *
+     * @return the base Solr URL to use in performing queries, or null if
+     * the "solr.suggest.server" property is not provided.
+     */
+    protected String getSolrServerUrl() {
+        ConfigurationService configurationService
+                = DSpaceServicesFactory.getInstance().getConfigurationService();
+        String solrServerUrl = configurationService.getProperty("solr.suggest.server");
+        return solrServerUrl;
+    }
+
+    protected SolrClient configureSolrClient(String solrServerUrl) {
+        log.debug("Solr suggest URL: " + solrServerUrl);
+        if (solrServerUrl == null) {
+            return null;
+        }
+
+        HttpSolrClient solrServer = new HttpSolrClient.Builder(solrServerUrl)
+                .withHttpClient(httpConnectionPoolService.getClient())
+                .withBaseSolrUrl(solrServerUrl)
+                .build();
+
+        if (canConnect(solrServer)) {
+            return solrServer;
+        }
+
+        log.error("Cannot connect to Solr suggest URL: " + solrServerUrl);
+        return null;
+    }
+
+    /**
+     * Returns true if a Solr connection can be made, false otherwise.
+     *
+     * @param solrServer the HttpSolrClient to use in making the connection
+     * @return true if a Solr connection can be made, false otherwise.
+     */
+    protected boolean canConnect(HttpSolrClient solrServer) {
+        SolrQuery solrQuery = new SolrQuery().setQuery("*:*");
+
+        try {
+            solrServer.query(solrQuery);
+        } catch (Exception ex) {
+            log.error("An error occurred querying the solr suggest server: '"  + solrServer.getBaseURL() + "'", ex);
+            return false;
+        }
+        return true;
+    }
+}

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SuggestChoiceAuthority.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SuggestChoiceAuthority.java
@@ -1,0 +1,121 @@
+package edu.umd.lib.dspace.content.authority;
+
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.authority.ChoiceAuthority;
+import org.dspace.content.authority.Choices;
+import org.dspace.core.NameAwarePlugin;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * ChoiceAuthority implementation that returns matches from a SuggestService
+ * implementation.
+ */
+public class SuggestChoiceAuthority implements ChoiceAuthority {
+    private Logger log = org.apache.logging.log4j.LogManager.getLogger(SuggestChoiceAuthority.class);
+
+    /**
+     * The DSpace configuration service instance
+     */
+    protected final ConfigurationService configurationService
+        = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    /**
+     * The name assigned to the specific instance by the PluginService,
+     * @see {@link NameAwarePlugin}
+     **/
+    protected String authorityName;
+
+    /**
+     * The SuggestService implementation to query
+     */
+    protected SuggestService suggestService;
+
+
+    @Override
+    public Choices getMatches(String text, int start, int limit, String locale) {
+        return getMatches(text, start, limit, locale, true);
+    }
+
+    @Override
+    public Choices getBestMatch(String text, String locale) {
+        Choices matches = getMatches(text, 0, 1, locale, false);
+        if (matches.values.length != 0 && !matches.values[0].value.equalsIgnoreCase(text)) {
+            matches = new Choices(false);
+        }
+        return matches;
+    }
+
+    /**
+     * Returns the Choices representing the suggestions for the given query
+     * text, which may be empty if there are not matches.
+     *
+     * @param text the text to use in generating the suggestions
+     * @param start the zero-based index of the choice at which to start
+     * @param limit the maximum number of choices to return.
+     * @return the Choices representing the suggestions for the given query
+     * text, which may be empty if there are not matches.
+     */
+    protected Choices getMatches(String text, int start, int limit, String locale,
+        boolean bestMatch) {
+        log.debug("Searching for " + text + " in " + authorityName);
+        if (limit == 0) {
+            limit = 10;
+        }
+
+        if (text == null || text.trim().equals("")) {
+            // Don't search for blank text, just return that nothing is found.
+            return new Choices(Choices.CF_NOTFOUND);
+        }
+
+        return suggestService.search(text, start, limit);
+    }
+
+    /**
+     * This method is required by the "ChoiceAuthority" interface.
+     * Since auto-suggest is not an actual authority, this method simply
+     * returns the provided "key", which is the text of a suggestion to
+     * display to the user.
+     *
+     * @param key a suggestion returned by Solr for display to the user
+     * @param locale ignored
+     * @return the given key
+     */
+    @Override
+    public String getLabel(String key, String locale) {
+        return key;
+    }
+
+    @Override
+    public void setPluginInstanceName(String name) {
+        configureInstance(name);
+    }
+
+    /**
+     * Configures this instance based on the given name.
+     *
+     * @param name the plugin name for this instance.
+     */
+    protected void configureInstance(String name) {
+        authorityName = name;
+
+        org.dspace.kernel.ServiceManager manager = DSpaceServicesFactory.getInstance().getServiceManager();
+        suggestService = manager.getServiceByName(SuggestService.class.getName(), SuggestService.class);
+        suggestService.configure(authorityName, this);
+    }
+
+    @Override
+    public String getPluginInstanceName() {
+        return authorityName;
+    }
+
+
+    /**
+     * Always returns false, because this implementation returns suggestions,
+     * not authority records.
+     */
+    @Override
+    public boolean storeAuthorityInMetadata() {
+        return false;
+    }
+}

--- a/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SuggestService.java
+++ b/dspace/modules/additions/src/main/java/edu/umd/lib/dspace/content/authority/SuggestService.java
@@ -1,0 +1,22 @@
+package edu.umd.lib.dspace.content.authority;
+
+import org.dspace.content.authority.ChoiceAuthority;
+import org.dspace.content.authority.Choices;
+
+public interface SuggestService {
+    /**
+     * Returns the Choices given query text, or an empty Choices object if
+     * there are not results, or an error occurs.
+     */
+    public Choices search(String queryText, int start, int limit);
+
+    /**
+     * Configures this service instance using the given authorityName and
+     * ChoiceAuthority.
+     *
+     * @param authorityName the name used to retrive the Solr dictionary to
+     * associated with this instance of the service.
+     * @param choiceAuthority the ChoiceAuthority that is using this service.
+     */
+    public void configure(String authorityName, ChoiceAuthority choiceAuthority);
+}

--- a/dspace/modules/additions/src/main/resources/spring/spring-dspace-addon-umd-custom-services.xml
+++ b/dspace/modules/additions/src/main/resources/spring/spring-dspace-addon-umd-custom-services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- This is a UMD custom file for configuring services added by UMD -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+    default-autowire-candidates="*Service,*DAO,javax.sql.DataSource">
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+    <bean class="edu.umd.lib.dspace.content.authority.SolrSuggestService" id="edu.umd.lib.dspace.content.authority.SuggestService"/>
+</beans>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -158,4 +158,44 @@
             <str>spellcheck</str>
         </arr>
     </requestHandler>
+
+    <!-- UMD Customization -->
+    <searchComponent name="suggest" class="solr.SuggestComponent">
+        <lst name="suggester">
+            <str name="name">formatSuggest</str>
+            <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="indexPath">format_suggester_infix_dir</str>
+            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+            <str name="field" multiValued="true">dc.genre</str>
+            <str name="suggestAnalyzerFieldType">text</str>
+            <str name="buildOnStartup">true</str>
+            <str name="buildOnCommit">true</str>
+            <str name="highlight">false</str>
+        </lst>
+        <lst name="suggester">
+            <str name="name">subjectSuggest</str>
+            <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="indexPath">subject_suggester_infix_dir</str>
+            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+            <str name="field" multiValued="true">dc.subject</str>
+            <str name="suggestAnalyzerFieldType">text</str>
+            <str name="buildOnStartup">true</str>
+            <str name="buildOnCommit">true</str>
+            <str name="highlight">false</str>
+        </lst>
+    </searchComponent>
+
+    <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy" >
+        <lst name="defaults">
+            <str name="suggest">true</str>
+            <str name="suggest.count">15</str>
+            <str name="suggest.dictionary">subjectSuggest</str>
+        </lst>
+
+        <str name="hl">false</str>
+        <arr name="components">
+            <str>suggest</str>
+        </arr>
+    </requestHandler>
+    <!-- End UMD Customization -->
 </config>


### PR DESCRIPTION
Initial implementation of Solr autosuggest functionality for the "Format" and "Subject Keywords" submission form fields.

This implementation is based on the stock DSpace "ChoiceAuthority" plugin functionality.

https://umd-dit.atlassian.net/browse/LIBCIR-297
