### PR TITLE
LIBCIR-336. Updated Simple Item page documentation for "Links to Files"

### DIFF
--- a/dspace/docs/SimpleItemPage.md
+++ b/dspace/docs/SimpleItemPage.md
@@ -59,6 +59,8 @@ Dspace 7 MD-SOAR, to better conform to the DSpace 7 look-and-feel.
   * `<From the DSpace object>`
 * Files
   * `<Links to all files in the DSpace object>`
+* Links to Files
+  * dc.description.uri
 * Permanent Link
   * dc.identifier.uri
 * Collections


### PR DESCRIPTION
Updated the "SimpleItemPage.md" documentation to record the "Links to Files" customization, which was missed in the original implementation.

https://umd-dit.atlassian.net/browse/LIBCIR-336