### PR TITLE
LIBCIR-340. Enable optimization for "select-collection-step" query

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -359,3 +359,6 @@ usage-statistics.logBots = false
 ######################
 # Only send subscription emails for new items
 eperson.subscription.onlynew = true
+
+# Enabling performance optimization for select-collection-step collection query
+org.dspace.content.Collection.findAuthorizedPerformanceOptimize = true

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -37,6 +37,12 @@ to override default settings in the stock DSpace configuration files.
 * `webui.user.assumelogin` - Enabled administrators to impersonate non-admin
     users
 
+* `org.dspace.content.Collection.findAuthorizedPerformanceOptimize` - Enabling
+  this property significantly speeds up the display of the submission form
+  for non-admins when selecting the “Submit item to MD-SOAR” link on the
+  home page. See the description for this property in "dspace/config/dspace.cfg"
+  for caveats on enabling this property (which do not apply to MD-SOAR).
+
 ### Email Templates
 
 The email templates in the "dspace/config/emails/" directory were modified to


### PR DESCRIPTION
Enabling the "org.dspace.content.Collection.findAuthorizedPerformanceOptimize" property significantly speeds up the display of the submission form for non-admins when selecting the “Submit item to MD-SOAR” link on the home page.

This property is not enabled by default (as outlined in https://github.com/DSpace/DSpace/issues/6033) because it is not compatible with Shibboleth or LDAP authentication and special groups. (see also the note for this property in "dspace/config/dspace.config".

Since MD-SOAR does not use Shibboeth or LDAP authentication, and has a large number of collection, it seems to meet the criteria for enabling this property.

https://umd-dit.atlassian.net/browse/LIBCIR-340

