### PR TITLE
LIBCIR-348. Make "Text" first entry in "Type" drop-down

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1634,6 +1634,11 @@
 
         <value-pairs value-pairs-name="common_types" dc-term="type">
             <!-- UMD Customization -->
+            <!-- "Text" is the first item, because it is the most commonly used. -->
+            <pair>
+              <displayed-value>Text</displayed-value>
+              <stored-value>Text</stored-value>
+            </pair>
             <pair>
               <displayed-value>Collection</displayed-value>
               <stored-value>Collection</stored-value>
@@ -1677,10 +1682,6 @@
             <pair>
               <displayed-value>Still Image</displayed-value>
               <stored-value>Still Image</stored-value>
-            </pair>
-            <pair>
-              <displayed-value>Text</displayed-value>
-              <stored-value>Text</stored-value>
             </pair>
             <!-- End UMD Customization -->
         </value-pairs>

--- a/dspace/docs/SubmissionForm.md
+++ b/dspace/docs/SubmissionForm.md
@@ -60,6 +60,7 @@ The following list was copied from the DSpace 6 version of MD-SOAR:
 
 | displayed-value      | stored-value         |
 | -------------------- | -------------------- |
+| Text                 | Text                 |
 | Collection           | Collection           |
 | Dataset              | Dataset              |
 | Event                | Event                |
@@ -71,7 +72,9 @@ The following list was copied from the DSpace 6 version of MD-SOAR:
 | Software             | Software             |
 | Sound                | Sound                |
 | Still Image          | Still Image          |
-| Text                 | Text                 |
+
+**Note:** As it is the most commonly selected entry, "Text" should be the first
+entry in the drop-down list on the submission form.
 
 ## Creative Commons License
 


### PR DESCRIPTION
Modified configuration so that the "Text" entry is the first entry in the the "Type" drop-down on the submission form.

https://umd-dit.atlassian.net/browse/LIBCIR-348

