### PR TITLE
LIBCIR-347. Disable item deletion for community and collection admins

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -300,6 +300,18 @@ webui.browse.link.6 = type:dc.type
 webui.browse.link.7 = type:dc.format
 webui.browse.link.8 = type:dcterms.format
 
+#################################
+# COMMUNITY ADMIN CONFIGURATION #
+#################################
+# Only system admins are allowed to permanently delete items
+core.authorization.community-admin.item.delete = false
+
+##################################
+# COLLECTION ADMIN CONFIGURATION #
+##################################
+# Only system admins are allowed to permanently delete items
+core.authorization.collection-admin.item.delete = false
+
 #####################
 # DOI CONFIGURATION #
 #####################

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -32,9 +32,11 @@
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
 dspace.dir=/dspace
 
+# UMD Customization
 dspace.hostname = localhost
 dspace.baseUrl = http://localhost:8080
 dspace.url = ${dspace.baseUrl}
+# End UMD Customization
 
 # Public URL of DSpace backend ('server' webapp). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
@@ -42,7 +44,9 @@ dspace.url = ${dspace.baseUrl}
 # NOTE: This URL must be accessible to all DSpace users (should not use 'localhost' in Production)
 # and is usually "synced" with the "rest" section in the DSpace User Interface's config.*.yml.
 # It corresponds to the URL that you would type into your browser to access the REST API.
+# UMD Customization
 dspace.server.url = ${dspace.baseUrl}/server
+# End UMD Customization
 
 # Public URL of DSpace frontend (Angular UI). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
@@ -52,7 +56,9 @@ dspace.server.url = ${dspace.baseUrl}/server
 dspace.ui.url = http://localhost:4000
 
 # Name of the site
+# UMD Customization
 dspace.name = MD-SOAR
+# End UMD Customization
 
 # Assetstore configurations have moved to config/modules/assetstore.cfg
 # and config/spring/api/bitstore.xml.
@@ -65,7 +71,9 @@ dspace.name = MD-SOAR
 # Solr server/webapp.
 # DSpace uses Solr for all search/browse capability (and for usage statistics).
 # Since DSpace 7, SOLR must be installed as a stand-alone service
+# UMD Customization
 solr.server = http://dspacesolr:8983/solr
+# End UMD Customization
 
 # Solr core name prefix.
 # If you connect multiple instances of DSpace to a single Solr instance, you
@@ -82,7 +90,9 @@ solr.server = http://dspacesolr:8983/solr
 # URL for connecting to database
 #    * Postgres template: jdbc:postgresql://localhost:5432/dspace
 #    * Oracle template (DEPRECATED): jdbc:oracle:thin:@//localhost:1521/xe
+# UMD Customization
 db.url = jdbc:postgresql://dspacedb:5432/mdsoar
+# End UMD Customization
 
 # JDBC Driver
 #    * For Postgres: org.postgresql.Driver
@@ -95,8 +105,10 @@ db.driver = org.postgresql.Driver
 db.dialect = org.hibernate.dialect.PostgreSQL94Dialect
 
 # Database username and password
+# UMD Customization
 db.username = mdsoar
 db.password = mdsoar
+# End UMD Customization
 
 # Database Schema name
 #    * For Postgres, this is often "public" (default schema)
@@ -141,7 +153,9 @@ db.schema = public
 #feedback.recipient = dspace-help@myu.edu
 
 # General site administration (Webmaster) e-mail
+# UMD Customization
 mail.admin = mdsoar-help@umd.edu
+# End UMD Customization
 
 # Helpdesk E-mail
 #mail.helpdesk = ${mail.admin}
@@ -256,6 +270,8 @@ mail.admin = mdsoar-help@umd.edu
 # Maximum size of a multipart request (i.e. max total size of all files in one request)
 #spring.servlet.multipart.max-request-size = 512MB
 
+# UMD Customization
+
 ########################
 # BROWSE CONFIGURATION #
 ########################
@@ -362,3 +378,5 @@ eperson.subscription.onlynew = true
 
 # Enabling performance optimization for select-collection-step collection query
 org.dspace.content.Collection.findAuthorizedPerformanceOptimize = true
+
+# End UMD Customization

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -43,6 +43,14 @@ to override default settings in the stock DSpace configuration files.
   home page. See the description for this property in "dspace/config/dspace.cfg"
   for caveats on enabling this property (which do not apply to MD-SOAR).
 
+* Only system admins should be able to permanently delete items, so the
+  following properties were added:
+  * `core.authorization.community-admin.item.delete`
+  * `core.authorization.collection-admin.item.delete`
+
+  Note: This also means that only system admins can move items to another
+  collection.
+
 ### Email Templates
 
 The email templates in the "dspace/config/emails/" directory were modified to


### PR DESCRIPTION
Only system admins should be able to permanently delete items, so
added properties to the "local.cfg.EXAMPLE" file to prevent community
and collection admins from permanently deleting items.

This also has the side effect of preventing community and collection
admins from moving items to a different collection.

Updated the documentation to describe this customization.

Also added "UMD Customization"/"End UMD Customization" markers
to all changes to the "local.cfg.EXAMPLE" file to simplify future DSpace
upgrades.

https://umd-dit.atlassian.net/browse/LIBCIR-347