### PR TITLE
LIBCIR-352. Enable all users to view usage statistics

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -376,9 +376,6 @@ webui.submit.upload.required = false
 ####################
 # Override settings in dspace/config/modules/usage-statistics.cfg
 
-# Suppress "Statistics" entry in the navbar for non-admins
-usage-statistics.authorization.admin.usage=true
-
 # Disable logging of spiders in solr statistics.
 usage-statistics.logBots = false
 

--- a/dspace/docs/MdsoarCustomizations.md
+++ b/dspace/docs/MdsoarCustomizations.md
@@ -28,9 +28,6 @@ to override default settings in the stock DSpace configuration files.
 * `usage-statistics.logBots` - Disable logging of spiders/bots in Solr
   statistics.
 
-* `usage-statistics.authorization.admin.usage` - Do not show "Statistics" menu
-  entry in the navbar for non-admins users.
-
 * Modified `webui.browse.index.<n>` entries, adding the ability to browse by
   "Type".
 


### PR DESCRIPTION
Restores the stock DSpace behavior of allowing all users (including anonymous users) to view the usage statistics.

This reverses an incorrect configuration change made to MD-SOAR in LIBCIR-299, which restricted the usage statistics to admins.

Also removed the property from the list of customized properties in "dspace/docs/MdsoarCustomizations.md"

https://umd-dit.atlassian.net/browse/LIBCIR-352
