### PR TITLE
LIBCIR-360. Send request item emails to community admins

### DIFF
--- a/dspace/config/spring/api/requestitem.xml
+++ b/dspace/config/spring/api/requestitem.xml
@@ -25,8 +25,10 @@
             This sends various emails between the requestor and the grantor.
         </description>
         <!-- Select the grantor discovery strategy here. -->
+        <!-- UMD Customization -->
         <constructor-arg index='0'
-                         ref='org.dspace.app.requestitem.RequestItemMetadataStrategy'/> 
+                         ref='org.dspace.app.requestitem.CollectionAdministratorsRequestItemStrategy'/>
+        <!-- End UMD Customization -->
     </bean>
 
     <bean class="org.dspace.app.requestitem.RequestItemMetadataStrategy"
@@ -34,7 +36,7 @@
         <description>
             Get recipients from an item metadata field.
         </description>
-        <!-- 
+        <!--
             Uncomment these properties if you want lookup in metadata
             the email and the name of the author to contact for request copy.
             If you don't configure that or if the requested item doesn't have

--- a/dspace/docs/DockerDevelopmentEnvironment.md
+++ b/dspace/docs/DockerDevelopmentEnvironment.md
@@ -283,7 +283,7 @@ stanza, to enable the "MailHog" (<https://github.com/mailhog/MailHog>) SMTP
 capture tool as part of the Docker Compose stack:
 
 ```yaml
-service:
+services:
   # MailHog SMTP Capture
   mailhog:
     container_name: mailhog


### PR DESCRIPTION
Followed the documentation instructions (see https://wiki.lyrasis.org/display/DSDOC7x/Request+a+Copy#RequestaCopy-ConfigureallrequeststogototheadministratorsofaCollection) and modified the “dspace/config/spring/api/requestitem.xml” file to use the “org.dspace.app.requestitem.CollectionAdministratorsRequestItemStrategy” strategy.

According to the documentation, this strategy will do the following:

* Send the request email to all the community administrators
* _If a community has no administrators, send an email to the help desk   email (if the “request.item.helpdesk.override” property is set to true_
  **Note:** In our current configuration the “request.item.helpdesk.override” property is false, so this step is skipped.
* Send the request email to the item submitter

The email setup instructions in "DockerDevelopmentEnvironment.md" were
intertwined with the "Testing File Download Counts" instructions, so
disentangled them and updated.

https://umd-dit.atlassian.net/browse/LIBCIR-360