### PR TITLE
LIBCIR-374. Revert customization sending doc requests to collection admin

### DIFF
--- a/dspace/config/spring/api/requestitem.xml
+++ b/dspace/config/spring/api/requestitem.xml
@@ -25,10 +25,8 @@
             This sends various emails between the requestor and the grantor.
         </description>
         <!-- Select the grantor discovery strategy here. -->
-        <!-- UMD Customization -->
         <constructor-arg index='0'
-                         ref='org.dspace.app.requestitem.CollectionAdministratorsRequestItemStrategy'/>
-        <!-- End UMD Customization -->
+                         ref='org.dspace.app.requestitem.RequestItemMetadataStrategy'/> 
     </bean>
 
     <bean class="org.dspace.app.requestitem.RequestItemMetadataStrategy"
@@ -36,7 +34,7 @@
         <description>
             Get recipients from an item metadata field.
         </description>
-        <!--
+        <!-- 
             Uncomment these properties if you want lookup in metadata
             the email and the name of the author to contact for request copy.
             If you don't configure that or if the requested item doesn't have


### PR DESCRIPTION
Reverted the change to the “dspace/config/spring/api/requestitem.xml” file for LIBCIR-360, restoring to the stock DSpace usage of the “org.dspace.app.requestitem.RequestItemMetadataStrategy” strategy.

Kept the other documentation-related changes made in LIBCIR-360, because they were still correct.

https://umd-dit.atlassian.net/browse/LIBCIR-374
