### PR TITLE
LIBCIR-419. Modify bitstore migration to skip missing files

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -402,6 +402,25 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
 
         while (allBitstreamsInSource.hasNext()) {
             Bitstream bitstream = allBitstreamsInSource.next();
+
+            // UMD Customization
+            // This customization was added to support migrating the asset store
+            // files in the Kubernetes "sandbox", "test" and "qa" namespaces to
+            // AWS S3 and can be removed after the AWS S3 migration is complete.
+            BitStoreService bitstore = getStore(bitstream.getStoreNumber());
+            if (bitstore instanceof DSBitStoreService) {
+                DSBitStoreService dsBitstoreService = (DSBitStoreService) bitstore;
+                if (!dsBitstoreService.exists(bitstream)) {
+                    log.info("Skipping bitstream:" + bitstream.getID() +
+                        " from assetstore[" + assetstoreSource + "] " +
+                        "Name:" + bitstream.getName() +
+                        ", SizeBytes:" + bitstream.getSizeBytes() +
+                        " because it does not exist in the asset store!");
+                    continue;
+                }
+            }
+            // End UMD Customization
+
             log.info("Copying bitstream:" + bitstream
                 .getID() + " from assetstore[" + assetstoreSource + "] to assetstore[" + assetstoreDestination + "] " +
                          "Name:" + bitstream

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -263,4 +263,18 @@ public class DSBitStoreService extends BaseBitStoreService {
     public void setBaseDir(File baseDir) {
         this.baseDir = baseDir;
     }
+
+    // UMD Customization
+    // This customization was added to support migrating the asset store
+    // files in the Kubernetes "sandbox", "test" and "qa" namespaces to
+    // AWS S3 and can be removed after the AWS S3 migration is complete.
+    public boolean exists(Bitstream bitstream)
+        throws IOException {
+        File file = getFile(bitstream);
+        if (file == null) {
+            return false;
+        }
+        return file.exists();
+    }
+    // End UMD Customization
 }


### PR DESCRIPTION
Modified the stock DSpace bitstore migration code to skip bitstreams that are not present in the assetstore.

While not needed for production, the ability to skip bitstreams is needed for the "sandbox", "test" and "qa" MD-SOAR migrations, as these instances have production database snapshots, but not all of the production bitstreams (the stock DSpace migration code fails with an error if any bitstream is missing).

The changes in this commit can be removed when the AWS S3 migration is complete.

https://umd-dit.atlassian.net/browse/LIBCIR-419
