### PR TITLE
LIBCIR-420. Fix reference to "drum-ant" Docker image in Dockefile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,7 +23,7 @@ RUN mvn package -Pdspace-rest && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM docker.lib.umd.edu/drum-ant:latest as ant_build
+FROM docker.lib.umd.edu/mdsoar-ant:latest as ant_build
 ARG TARGET_DIR=dspace-installer
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src


### PR DESCRIPTION
Modified the "Dockerfile.dev" file to fix a likely copy-paste issue where the file references the "docker.lib.umd.edu/drum-ant:latest" Docker image instead of the "docker.lib.umd.edu/mdsoar-ant:latest" Docker image.

This likely occurred when performing the DSpace 7 upgrade, and aligning the files between DRUM and MD-SOAR.

This issue does not affect the Docker images generated for use in Kubernetes, as those images are generated using the “Dockerfile” file.

https://umd-dit.atlassian.net/browse/LIBCIR-420
