### PR TITLE
LIBCIR-423. Back-port of DSpace 7.6.3 "ssrBaseUrl" functionality

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RootRestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RootRestResourceController.java
@@ -44,6 +44,6 @@ public class RootRestResourceController {
 
     @RequestMapping(method = RequestMethod.GET)
     public RootResource listDefinedEndpoint(HttpServletRequest request) {
-        return converter.toResource(rootRestRepository.getRoot());
+        return converter.toResource(rootRestRepository.getRoot(request));
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -9,6 +9,8 @@ package org.dspace.app.rest.converter;
 
 import static org.dspace.app.util.Util.getSourceVersion;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.dspace.app.rest.model.RootRest;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +25,21 @@ public class RootConverter {
     @Autowired
     private ConfigurationService configurationService;
 
-    public RootRest convert() {
+    public RootRest convert(HttpServletRequest request) {
         RootRest rootRest = new RootRest();
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
-        rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
+        String requestUrl = request.getRequestURL().toString();
+        String dspaceUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceSSRUrl = configurationService.getProperty("dspace.server.ssr.url", dspaceUrl);
+        if (!dspaceUrl.equals(dspaceSSRUrl) && requestUrl.startsWith(dspaceSSRUrl)) {
+            rootRest.setDspaceServer(dspaceSSRUrl);
+        } else {
+            rootRest.setDspaceServer(dspaceUrl);
+        }
         rootRest.setDspaceVersion("DSpace " + getSourceVersion());
         return rootRest;
     }
+
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RootRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RootRestRepository.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.rest.repository;
 
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.dspace.app.rest.converter.RootConverter;
 import org.dspace.app.rest.model.RootRest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +24,7 @@ public class RootRestRepository {
     @Autowired
     RootConverter rootConverter;
 
-    public RootRest getRoot() {
-        return rootConverter.convert();
+    public RootRest getRoot(HttpServletRequest request) {
+        return rootConverter.convert(request);
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -837,7 +837,6 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
             .andExpect(status().isBadRequest());
     }
 
-    @Test
     /**
      * Verify that the search by object works properly in allowed scenarios, when SSR rest url is defined, :
      * - for an administrator

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -28,6 +28,10 @@ csvexport.dir = ${dspace.dir}/exports
 # and is usually "synced" with the "rest" section in the DSpace User Interface's config.*.yml.
 # It corresponds to the URL that you would type into your browser to access the REST API.
 dspace.server.url = http://localhost:8080/server
+# Additional URL of DSpace backend which could be used by DSpace frontend during SSR execution.
+# May require a port number if not using standard ports (80 or 443)
+# DO NOT end it with '/'.
+dspace.server.ssr.url = ${dspace.server.url}
 
 # Public URL of DSpace frontend (Angular UI). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -48,6 +48,11 @@ dspace.url = ${dspace.baseUrl}
 dspace.server.url = ${dspace.baseUrl}/server
 # End UMD Customization
 
+# Additional URL of DSpace backend which could be used by DSpace frontend during SSR execution.
+# May require a port number if not using standard ports (80 or 443)
+# DO NOT end it with '/'.
+dspace.server.ssr.url = ${dspace.server.url}
+
 # Public URL of DSpace frontend (Angular UI). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.


### PR DESCRIPTION
Back-port of "ssrBaseUrl" functionality from
DSpace pull request 10378

Implements the ability for Angular Universal to
communicate directly with the MD-SOAR back-end
pod, instead of going through the ingress.

This change was needed for the AWS migration.

https://umd-dit.atlassian.net/browse/LIBCIR-423
