### PR TITLE
LIBCIR-449. Remove "English (United States)" from submission form

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1690,18 +1690,21 @@
              "en_US", "en", "es", "de", "fr", "it", "ja", "zh", "other", ""
           -->
         <value-pairs value-pairs-name="common_iso_languages" dc-term="language_iso">
-            <pair>
-                <displayed-value>N/A</displayed-value>
-                <stored-value></stored-value>
-            </pair>
-            <pair>
+            <!-- UMD Customization -->
+            <!-- <pair>
                 <displayed-value>English (United States)</displayed-value>
                 <stored-value>en_US</stored-value>
-            </pair>
+            </pair> -->
+            <!-- "English" should be first entry in the list. -->
             <pair>
                 <displayed-value>English</displayed-value>
                 <stored-value>en</stored-value>
             </pair>
+            <pair>
+                <displayed-value>N/A</displayed-value>
+                <stored-value></stored-value>
+            </pair>
+            <!-- End UMD Customization -->
             <pair>
                 <displayed-value>Spanish</displayed-value>
                 <stored-value>es</stored-value>

--- a/dspace/docs/SubmissionForm.md
+++ b/dspace/docs/SubmissionForm.md
@@ -54,6 +54,11 @@ The stock DSpace list was maintained, with one additional entry:
 | --------------- | ------------ |
 | DOI             | uri          |
 
+### common_iso_languages
+
+"English (United States)" has been commented out, and "English" has been made
+the first item in the list (instead of stock DSpace "N/A" entry).
+
 ### common_types
 
 The following list was copied from the DSpace 6 version of MD-SOAR:


### PR DESCRIPTION
To address the proliferation of duplicate metadata columns, removed "English (United States)" from the "Language" drop-down in the submission form.

Also, moved "English" to be the first entry in the drop-down, above "N/A".

Added documentation for this customization in
"dspace/docs/SubmissionForm.md".

https://umd-dit.atlassian.net/browse/LIBCIR-449
