### PR TITLE
LIBCIR-451. Replace Author/Contributor/Advisor hint text with I18n keys

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -63,9 +63,7 @@
                     <input-type>onebox</input-type>
                     <!-- UMD Customization -->
                     <hint>
-                        Enter the name(s) of the author(s) of this item. To add
-                        multiple authors, enter one name (last and first)
-                        at a time and then click "Add more".
+                        submission.hint.dc.contributor.author
                     </hint>
                     <!-- End UMD Customization -->
                     <required></required>
@@ -102,10 +100,7 @@
                     <label>Contributor(s)</label>
                     <input-type>onebox</input-type>
                     <hint>
-                        Enter the name(s) of any other contributors to the item
-                        (e.g. editors, illustrators, narrators, etc.). To add
-                        multiple contributors, enter one name (last and first)
-                        at a time and then click "Add more".
+                        submission.hint.dc.contributor
                     </hint>
                     <required></required>
                 </field>
@@ -120,11 +115,8 @@
                     <label>Advisor(s)</label>
                     <input-type>onebox</input-type>
                     <hint>
-                        If applicable, enter the name(s) of the advisor(s) who
-                        oversaw the creation of this item. To add multiple
-                        advisors, enter one name (last and first) at a time and
-                        then click "Add more".
-		                </hint>
+                        submission.hint.dc.contributor.advisor
+		            </hint>
                     <required></required>
                 </field>
             </row>

--- a/dspace/docs/SubmissionForm.md
+++ b/dspace/docs/SubmissionForm.md
@@ -41,6 +41,23 @@ Fields are listed in the order that they appear on the form.
 * Note (4): Dropdown using "common_iso_languages" value-pairs list
 * Note (5): In DSpace 6, uses Solr-based auto-suggest
 
+## Form Field Hints
+
+The "hint" attribute for the following fields uses an I18n key instead of
+hard-coding the text:
+
+| Schema Field           | "hint" I18n Key                        |
+| ---------------------- | -------------------------------------- |
+| dc.contributor.author  | submission.hint.dc.contributor.author  |
+| dc.contributor.advisor | submission.hint.dc.contributor.advisor |
+| dc.contributor         | submission.hint.dc.contributor         |
+
+The text for the hints is specified in the “src/assets/i18n/en.json5”
+localization file in the Angular front-end.
+
+I18n keys are used for these fields to allow for HTML tags to be used as part of
+hint text.
+
 ## Value-Pairs Lists
 
 The following value-pair lists were customized in DSpace 6, and seemed


### PR DESCRIPTION
The MD-SOAR Community Admins have requested changes to the "hints" for the "Author(s)", "Contributor(s)", and "Advisor(s)" fields on the submission form to make more prominent that the names should be in "Last Name, First Name" format. The requested changes include using **bold** text in the hint.

Any HTML tags added directly to the hint text are displayed AS-IS in GUI, instead of being interpreted by the browser. To enable HTML tags to be included in the hints, replaced the hard-coded text with I18n keys, that can then be used with Angular's "translate" module to retrieve the text from an Angular front-end localization file (such as “src/assets/i18n/en.json5”). Text retrieved from a localization file can use a limited subset of HTML tags (include "<b>" and "<strong>").

https://umd-dit.atlassian.net/browse/LIBCIR-451
